### PR TITLE
Add backend mock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # travelmate-ai
+
 An AI-powered travel planning tool.
+
+## Backend Setup
+
+The backend uses Node.js with Express. Navigate to the `backend` folder and install dependencies:
+
+```bash
+cd backend
+npm install
+```
+
+### Environment Variables
+
+Create a `.env` file in `backend` with the following variables:
+
+- `OPENAI_API_KEY` – API key for OpenAI (required if enabling GPT itinerary generation).
+- `PORT` – Port number for the server (defaults to `3001`).
+
+### Running the Server
+
+Start the server in development mode using nodemon:
+
+```bash
+npm run dev
+```
+
+Or run it directly:
+
+```bash
+npm start
+```
+
+The server exposes a POST `/api/itinerary` endpoint that accepts JSON with
+`destination`, `dates`, `budget`, and `preferences` and returns a mock itinerary.
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "travelmate-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "openai": "^3.2.1"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(cors());
+app.use(express.json());
+
+// POST /api/itinerary
+// Expected input JSON: { destination, dates, budget, preferences }
+app.post('/api/itinerary', (req, res) => {
+  const { destination, dates, budget, preferences } = req.body;
+
+  // TODO: Validate input as needed
+
+  // Here you would call OpenAI GPT or any other service to generate
+  // an itinerary based on the provided parameters.
+  // Example: const itinerary = await openai.generateItinerary(...);
+
+  // For now, return a mock itinerary.
+  const itinerary = {
+    destination,
+    dates,
+    budget,
+    preferences,
+    days: [
+      { day: 1, activities: ['Visit local museum', 'Lunch at cafe'] },
+      { day: 2, activities: ['City tour', 'Dinner cruise'] }
+    ]
+  };
+
+  res.json(itinerary);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- set up `backend` package with Express
- implement mock itinerary endpoint
- document environment variables and backend usage

## Testing
- `node backend/server.js` *(fails: Cannot find package 'express')*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857e7e785608333b8a7a43061d98623